### PR TITLE
Fix hidden navigation on small screens

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -13,7 +13,11 @@
     <nav class="navbar">
         <div class="container">
             <a href="index.html" class="logo">Playlist Transfer</a>
-            <ul class="nav-links">
+            <button type="button" class="mobile-menu-toggle" aria-expanded="false" aria-controls="primary-navigation">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="hamburger" aria-hidden="true"></span>
+            </button>
+            <ul class="nav-links" id="primary-navigation">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="privacy.html">Privacy Policy</a></li>
@@ -75,5 +79,6 @@
             </div>
         </div>
     </footer>
+    <script src="js/main.js"></script>
 </body>
-</html> 
+</html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -52,6 +52,10 @@ body {
     gap: 40px;
 }
 
+.nav-links.nav-links--open {
+    display: flex;
+}
+
 .nav-links a {
     text-decoration: none;
     color: #4a4a4a;
@@ -62,6 +66,80 @@ body {
 
 .nav-links a:hover {
     color: #6366F1;
+}
+
+.mobile-menu-toggle {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border: none;
+    border-radius: 50%;
+    background: rgba(99,102,241,0.1);
+    cursor: pointer;
+    transition: background 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.mobile-menu-toggle:hover {
+    background: rgba(99,102,241,0.15);
+    transform: translateY(-1px);
+    box-shadow: 0 8px 20px rgba(99,102,241,0.25);
+}
+
+.mobile-menu-toggle:active {
+    transform: translateY(1px);
+}
+
+.mobile-menu-toggle .hamburger,
+.mobile-menu-toggle .hamburger::before,
+.mobile-menu-toggle .hamburger::after {
+    position: relative;
+    display: block;
+    width: 20px;
+    height: 2px;
+    background: #1a1a1a;
+    border-radius: 999px;
+    transition: transform 0.3s ease, opacity 0.3s ease, background 0.3s ease;
+}
+
+.mobile-menu-toggle .hamburger::before,
+.mobile-menu-toggle .hamburger::after {
+    content: '';
+    position: absolute;
+    left: 0;
+}
+
+.mobile-menu-toggle .hamburger::before {
+    top: -6px;
+}
+
+.mobile-menu-toggle .hamburger::after {
+    top: 6px;
+}
+
+.mobile-menu-toggle[aria-expanded="true"] .hamburger {
+    background: transparent;
+}
+
+.mobile-menu-toggle[aria-expanded="true"] .hamburger::before {
+    transform: translateY(6px) rotate(45deg);
+}
+
+.mobile-menu-toggle[aria-expanded="true"] .hamburger::after {
+    transform: translateY(-6px) rotate(-45deg);
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 /* Enhanced Hero Section */
@@ -205,11 +283,39 @@ footer {
     .hero h1 {
         font-size: 2.5rem;
     }
-    
+
+    .navbar .container {
+        position: relative;
+    }
+
+    .mobile-menu-toggle {
+        display: flex;
+    }
+
     .nav-links {
         display: none;
+        position: absolute;
+        top: 80px;
+        left: 24px;
+        right: 24px;
+        flex-direction: column;
+        gap: 16px;
+        background: #ffffff;
+        padding: 20px;
+        border-radius: 16px;
+        box-shadow: 0 15px 40px rgba(15, 23, 42, 0.15);
+        border: 1px solid rgba(99,102,241,0.15);
     }
-    
+
+    .nav-links.nav-links--open {
+        display: flex;
+    }
+
+    .nav-links a {
+        font-size: 1rem;
+        padding: 8px 0;
+    }
+
     .feature-grid {
         grid-template-columns: 1fr;
         gap: 40px;

--- a/index.html
+++ b/index.html
@@ -13,7 +13,11 @@
     <nav class="navbar">
         <div class="container">
             <a href="index.html" class="logo">Playlist Transfer</a>
-            <ul class="nav-links">
+            <button type="button" class="mobile-menu-toggle" aria-expanded="false" aria-controls="primary-navigation">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="hamburger" aria-hidden="true"></span>
+            </button>
+            <ul class="nav-links" id="primary-navigation">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="privacy.html">Privacy Policy</a></li>
@@ -63,5 +67,6 @@
             </div>
         </div>
     </footer>
+    <script src="js/main.js"></script>
 </body>
-</html> 
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const menuToggle = document.querySelector('.mobile-menu-toggle');
+    const navLinks = document.querySelector('.nav-links');
+
+    if (!menuToggle || !navLinks) {
+        return;
+    }
+
+    const closeMenu = () => {
+        menuToggle.setAttribute('aria-expanded', 'false');
+        navLinks.classList.remove('nav-links--open');
+    };
+
+    menuToggle.addEventListener('click', () => {
+        const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+        menuToggle.setAttribute('aria-expanded', String(!isExpanded));
+        navLinks.classList.toggle('nav-links--open', !isExpanded);
+    });
+
+    navLinks.querySelectorAll('a').forEach((link) => {
+        link.addEventListener('click', () => {
+            if (window.innerWidth <= 768) {
+                closeMenu();
+            }
+        });
+    });
+
+    window.addEventListener('resize', () => {
+        if (window.innerWidth > 768) {
+            closeMenu();
+        }
+    });
+});

--- a/privacy.html
+++ b/privacy.html
@@ -13,7 +13,11 @@
     <nav class="navbar">
         <div class="container">
             <a href="index.html" class="logo">Playlist Transfer</a>
-            <ul class="nav-links">
+            <button type="button" class="mobile-menu-toggle" aria-expanded="false" aria-controls="primary-navigation">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="hamburger" aria-hidden="true"></span>
+            </button>
+            <ul class="nav-links" id="primary-navigation">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="privacy.html">Privacy Policy</a></li>
@@ -95,5 +99,6 @@
             </div>
         </div>
     </footer>
+    <script src="js/main.js"></script>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
## Summary
- add a mobile menu toggle to the shared navigation so links remain available on small screens
- style the responsive dropdown menu and animated icon in the global stylesheet
- initialize the toggle logic on every page via a shared JavaScript file

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d01d3b82ac832682a388cfd06ee619